### PR TITLE
fix ios yieldlove library import

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,6 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))

--- a/ios/AppsFlutterYieldloveSDK.podspec
+++ b/ios/AppsFlutterYieldloveSDK.podspec
@@ -15,7 +15,8 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.dependency 'YieldloveAdIntegration'
+  s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/ios/Classes/SwiftAppsFlutterYieldloveSDKPlugin.swift
+++ b/ios/Classes/SwiftAppsFlutterYieldloveSDKPlugin.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import YieldloveAdIntegration
 
 // TODO best example I found so far: https://github.com/kmcgill88/admob_flutter/tree/master/ios
 
@@ -17,6 +18,7 @@ public class SwiftAppsFlutterYieldloveSDKPlugin: NSObject, FlutterPlugin {
   }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+      //Yieldlove.instance.interstitialAd(AdUnit: "example_ios_interstitial_1", UIViewController: self)
       result(true)
     }
 }


### PR DESCRIPTION
Ok, das mit dem Importing scheint zu klappen. Man musste nur diese dumme Zeile löschen:
> use_frameworks

Das habe ich bereits commitet

Jetzt fehlt es 'nur' an die Application ID :D Die App crasht also mit folgender Meldung: 
```
Terminating app due to uncaught exception 'GADInvalidInitializationException', reason: 'The Google Mobile Ads SDK was initialized without an application ID. Google AdMob publishers, follow instructions at https://googlemobileadssdk.page.link/admob-ios-update-plist to set a valid application ID. Google Ad Manager publishers, follow instructions at https://googlemobileadssdk.page.link/ad-manager-ios-update-plist.
```

PS1:
Wenn das Bauen bei dir wieder nicht geht, dann probiere es mal bitte mit folgenden Befehlen:
```
flutter clean
rm -rf ios/Flutter/Flutter.framework
rm ios/Podfile
rm ios/Podfile.lock
```

PS2:
ich starte die App über XCode. Da habe ich folgenden Runner geöffnet: 
<img width="418" alt="Screenshot 2020-10-27 at 17 53 55" src="https://user-images.githubusercontent.com/10563336/97335146-c6c96c80-187d-11eb-8e1a-2522fd885275.png">
