### PR TITLE
Fix privacy manager bug

### DIFF
--- a/lib/YieldloveWrapper.dart
+++ b/lib/YieldloveWrapper.dart
@@ -43,11 +43,11 @@ class YieldloveWrapper {
     /// always the same for Ströer Group
     var sourcepointAccountId = 375;
 
-    var propertyId = 10452;
+    var propertyId = Environment.isAndroid ? 17391 : 17390;
 
-    var propertyName = 'android.app.wetter.info';
+    var propertyName =  Environment.isAndroid ? 'android.app.new.wetter.info' : 'ios.app.new.wetter.info';
 
-    var privacyManagerId = '305923';
+    var privacyManagerId = Environment.isAndroid? '503921' : '503924';
 
     var response = await http.get(_yieldloveConfigUrl());
     if (response.statusCode == 200) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   sourcepoint_cmp:
     git:
-      url: https://github.com/cschellhas/sourcepoint_cmp
+      url: https://github.com/0phelia/sourcepoint_cmp
   http: ">=0.12.2"
   visibility_aware_state: ^1.0.2
 


### PR DESCRIPTION
- use another depedency for sourcepoint library (previous had a bug which caused the default third-party privacy manager to be shown on iOS; initial consent was ok)
- set new default values for Yieldlove sdk (falls back to the ones for Flutter Wetter App)